### PR TITLE
#555 [Layout] change opened variable name

### DIFF
--- a/packages/mui-layout/src/__tests__/context.test.js
+++ b/packages/mui-layout/src/__tests__/context.test.js
@@ -48,12 +48,12 @@ describe('context', () => {
     );
 
     expect(result).toMatchObject({
-      opened: false,
-      setOpened: expect.any(Function),
+      open: false,
+      setOpen: expect.any(Function),
       collapsed: false,
       setCollapsed: expect.any(Function),
-      secondaryOpened: false,
-      setSecondaryOpened: expect.any(Function),
+      secondaryOpen: false,
+      setSecondaryOpen: expect.any(Function),
       secondaryCollapsed: false,
       setSecondaryCollapsed: expect.any(Function),
     });

--- a/packages/mui-layout/src/__tests__/models/container.test.js
+++ b/packages/mui-layout/src/__tests__/models/container.test.js
@@ -56,7 +56,7 @@ describe('Container', () => {
 
     // set primary edge to persistent
     provider.primarySidebar.setVariant('persistent');
-    provider.set({ opened: false, collapsed: false });
+    provider.set({ open: false, collapsed: false });
     expect(container.getMarginStyle()).toStrictEqual({
       marginLeft: 0,
     });
@@ -64,7 +64,7 @@ describe('Container', () => {
       width: '100%',
     });
 
-    provider.set({ opened: true, collapsed: true });
+    provider.set({ open: true, collapsed: true });
     expect(container.getMarginStyle()).toStrictEqual({
       marginLeft: 80,
     });

--- a/packages/mui-layout/src/__tests__/models/content.test.js
+++ b/packages/mui-layout/src/__tests__/models/content.test.js
@@ -43,7 +43,7 @@ describe('Content', () => {
 
     provider.secondarySidebar.setVariant('persistent');
     provider.content.setSecondaryPersistentBehavior('fit');
-    provider.set({ secondaryOpened: false });
+    provider.set({ secondaryOpen: false });
     expect(content.getMarginStyle()).toStrictEqual({
       marginLeft: 256,
       marginRight: 0,
@@ -51,7 +51,7 @@ describe('Content', () => {
     expect(content.getWidthStyle()).toStrictEqual({
       width: 'calc(100% - 256px)',
     });
-    provider.set({ secondaryOpened: true });
+    provider.set({ secondaryOpen: true });
     expect(content.getMarginStyle()).toStrictEqual({
       marginLeft: 256,
       marginRight: 244,
@@ -61,7 +61,7 @@ describe('Content', () => {
     });
 
     provider.content.setSecondaryPersistentBehavior('flexible');
-    provider.set({ secondaryOpened: true });
+    provider.set({ secondaryOpen: true });
     expect(content.getMarginStyle()).toStrictEqual({
       marginLeft: 'calc(256px + -244px)',
     });

--- a/packages/mui-layout/src/__tests__/models/edgeEffect.test.js
+++ b/packages/mui-layout/src/__tests__/models/edgeEffect.test.js
@@ -77,9 +77,9 @@ describe('Edge Effect', () => {
     expect(effect.getMarginStyle()).toStrictEqual({ marginLeft: 80 });
 
     provider.primarySidebar.setVariant('persistent');
-    provider.set({ opened: false, collapsed: false });
+    provider.set({ open: false, collapsed: false });
     expect(effect.getMarginStyle()).toStrictEqual({ marginLeft: 0 });
-    provider.set({ opened: true, collapsed: false });
+    provider.set({ open: true, collapsed: false });
     // no persistentBehavior provided
     expect(effect.getMarginStyle()).toStrictEqual({ marginLeft: 0 });
     // contain persistentBehavior
@@ -109,9 +109,9 @@ describe('Edge Effect', () => {
     expect(effect.getMarginStyle()).toStrictEqual({ marginRight: 64 });
 
     provider.primarySidebar.setVariant('persistent');
-    provider.set({ opened: false, collapsed: false });
+    provider.set({ open: false, collapsed: false });
     expect(effect.getMarginStyle()).toStrictEqual({ marginRight: 0 });
-    provider.set({ opened: true, collapsed: false });
+    provider.set({ open: true, collapsed: false });
     // no persistentBehavior provided
     expect(effect.getMarginStyle()).toStrictEqual({ marginRight: 0 });
     // contain persistentBehavior
@@ -123,17 +123,17 @@ describe('Edge Effect', () => {
     // should only affect marginLeft as negative value, otherwise does not work
     // css constraint
     // todo support rtl direction
-    provider.set({ opened: true, collapsed: false });
+    provider.set({ open: true, collapsed: false });
     expect(effect.getMarginStyle(BEHAVIOR.flexible)).toStrictEqual({
       marginLeft: -300,
     });
-    provider.set({ opened: true, collapsed: true });
+    provider.set({ open: true, collapsed: true });
     expect(effect.getMarginStyle(BEHAVIOR.flexible)).toStrictEqual({
       marginLeft: -64,
     });
 
     provider.primarySidebar.setWidth('30%');
-    provider.set({ opened: true, collapsed: false });
+    provider.set({ open: true, collapsed: false });
     expect(effect.getMarginStyle(BEHAVIOR.flexible)).toStrictEqual({
       marginLeft: '-30%',
     });
@@ -160,9 +160,9 @@ describe('Edge Effect', () => {
     });
 
     provider.primarySidebar.setVariant('persistent');
-    provider.set({ opened: false, collapsed: false });
+    provider.set({ open: false, collapsed: false });
     expect(effect.getWidthStyle()).toStrictEqual({ width: '100%' });
-    provider.set({ opened: true, collapsed: false });
+    provider.set({ open: true, collapsed: false });
     expect(effect.getWidthStyle()).toStrictEqual({ width: '100%' });
     expect(effect.getWidthStyle(BEHAVIOR.flexible)).toStrictEqual({
       width: '100%',
@@ -170,7 +170,7 @@ describe('Edge Effect', () => {
     expect(effect.getWidthStyle(BEHAVIOR.fit)).toStrictEqual({
       width: 'calc(100% - 300px)',
     });
-    provider.set({ opened: true, collapsed: true });
+    provider.set({ open: true, collapsed: true });
     expect(effect.getWidthStyle(BEHAVIOR.fit)).toStrictEqual({
       width: 'calc(100% - 64px)',
     });

--- a/packages/mui-layout/src/__tests__/models/footer.test.js
+++ b/packages/mui-layout/src/__tests__/models/footer.test.js
@@ -61,14 +61,14 @@ describe('Footer', () => {
     provider.secondarySidebar.setWidth(244);
     provider.secondarySidebar.setAnchor('right');
     provider.secondarySidebar.setVariant('permanent');
-    provider.set({ opened: false, collapsed: false });
+    provider.set({ open: false, collapsed: false });
     expect(footer.getMarginStyle()).toStrictEqual({
       marginLeft: 0,
       marginRight: 244,
     });
     expect(footer.getWidthStyle()).toStrictEqual({ width: 'auto' });
 
-    provider.set({ opened: true, collapsed: false });
+    provider.set({ open: true, collapsed: false });
     expect(footer.getMarginStyle()).toStrictEqual({
       marginLeft: 256,
       marginRight: 244,

--- a/packages/mui-layout/src/__tests__/models/header.test.js
+++ b/packages/mui-layout/src/__tests__/models/header.test.js
@@ -61,7 +61,7 @@ describe('Header', () => {
     provider.header.setSecondaryClipped(false);
     provider.header.setSecondaryPersistentBehavior('fit');
     provider.secondarySidebar.setVariant('persistent');
-    provider.set({ secondaryOpened: false });
+    provider.set({ secondaryOpen: false });
     expect(header.getMarginStyle()).toStrictEqual({
       marginLeft: 256,
       marginRight: 0,
@@ -69,7 +69,7 @@ describe('Header', () => {
     expect(header.getWidthStyle()).toStrictEqual({
       width: 'calc(100% - 256px)',
     });
-    provider.set({ secondaryOpened: true });
+    provider.set({ secondaryOpen: true });
     expect(header.getMarginStyle()).toStrictEqual({
       marginLeft: 256,
       marginRight: 244,
@@ -121,7 +121,7 @@ describe('Header', () => {
     });
     expect(header.getWidthStyle()).toStrictEqual({ width: '100%' });
 
-    provider.set({ opened: true });
+    provider.set({ open: true });
     expect(header.getMarginStyle()).toStrictEqual({
       marginLeft: 256,
     });

--- a/packages/mui-layout/src/__tests__/secondarySidebar.test.js
+++ b/packages/mui-layout/src/__tests__/secondarySidebar.test.js
@@ -49,7 +49,7 @@ describe('[Layout_RightSidebar]', function() {
     expect(sidebarPaper.style.visibility).toBe('');
   });
 
-  test('[Temporary] should appear in dom when opened', () => {
+  test('[Temporary] should appear in dom when open', () => {
     const { queryByTestId, getByTestId } = renderWithinLayout(
       <>
         <SecondarySidebar

--- a/packages/mui-layout/src/__tests__/sidebar.test.js
+++ b/packages/mui-layout/src/__tests__/sidebar.test.js
@@ -48,7 +48,7 @@ describe('[Layout_LeftSidebar]', function() {
     expect(sidebarPaper.style.visibility).toBe('');
   });
 
-  test('[Temporary] should appear in dom when opened', () => {
+  test('[Temporary] should appear in dom when open', () => {
     const { queryByTestId, getByTestId } = renderWithinLayout(
       <>
         <Sidebar

--- a/packages/mui-layout/src/adapters/sidebar.js
+++ b/packages/mui-layout/src/adapters/sidebar.js
@@ -2,8 +2,8 @@ const SidebarAdapter = () => ({});
 
 SidebarAdapter.mapSecondaryConfig = ({
   secondarySidebar,
-  secondaryOpened,
-  setSecondaryOpened,
+  secondaryOpen,
+  setSecondaryOpen,
   secondaryCollapsed,
   setSecondaryCollapsed,
   secondaryClipped,
@@ -24,10 +24,10 @@ SidebarAdapter.mapSecondaryConfig = ({
 } = {}) => ({
   ...rest,
   sidebar: secondarySidebar,
-  opened: secondaryOpened,
+  open: secondaryOpen,
   collapsed: secondaryCollapsed,
   clipped: secondaryClipped,
-  setOpened: setSecondaryOpened,
+  setOpen: setSecondaryOpen,
   setCollapsed: setSecondaryCollapsed,
   autoCollapseDisabled: secondaryAutoCollapseDisabled,
   collapseBreakpoint: secondaryCollapseBreakpoint,

--- a/packages/mui-layout/src/components/CollapseBtn.d.ts
+++ b/packages/mui-layout/src/components/CollapseBtn.d.ts
@@ -9,7 +9,7 @@ export type CollapseBtnTypeMap<
   D extends ElementType = 'button'
 > = ExtendButtonTypeMap<{
   props: P & {
-    mapContext?: (ctx: ReturnType<typeof useSidebarConfig>) => Pick<ReturnType<typeof useSidebarConfig>, 'setCollapsed' | 'collapsed' | 'opened' | 'sidebar'>;
+    mapContext?: (ctx: ReturnType<typeof useSidebarConfig>) => Pick<ReturnType<typeof useSidebarConfig>, 'setCollapsed' | 'collapsed' | 'open' | 'sidebar'>;
     // useSidebarConfig?: typeof useSidebarConfig;
   };
   defaultComponent: D;

--- a/packages/mui-layout/src/components/SecondaryCollapseBtn.d.ts
+++ b/packages/mui-layout/src/components/SecondaryCollapseBtn.d.ts
@@ -9,7 +9,7 @@ export type SecondaryCollapseBtnTypeMap<
   D extends ElementType = 'button'
 > = ExtendButtonTypeMap<{
   props: P & {
-    mapContext?: (ctx: ReturnType<typeof useSidebarConfig>) => Pick<ReturnType<typeof useSidebarConfig>, 'setCollapsed' | 'collapsed' | 'opened' | 'sidebar'>;
+    mapContext?: (ctx: ReturnType<typeof useSidebarConfig>) => Pick<ReturnType<typeof useSidebarConfig>, 'setCollapsed' | 'collapsed' | 'open' | 'sidebar'>;
     // useSidebarConfig?: typeof useSidebarConfig;
   };
   defaultComponent: D;

--- a/packages/mui-layout/src/components/internal/SharedCollapseBtn.d.ts
+++ b/packages/mui-layout/src/components/internal/SharedCollapseBtn.d.ts
@@ -15,7 +15,7 @@ export type SharedCollapseBtnTypeMap<
   D extends ElementType = 'button'
 > = ExtendButtonTypeMap<{
   props: P & {
-    mapContext?: (ctx: ReturnType<typeof useSidebarConfig>) => Pick<ReturnType<typeof useSidebarConfig>, 'setCollapsed' | 'collapsed' | 'opened' | 'sidebar'>;
+    mapContext?: (ctx: ReturnType<typeof useSidebarConfig>) => Pick<ReturnType<typeof useSidebarConfig>, 'setCollapsed' | 'collapsed' | 'open' | 'sidebar'>;
     useSidebarConfig: typeof useSidebarConfig;
   };
   defaultComponent: D;

--- a/packages/mui-layout/src/components/internal/SharedCollapseBtn.js
+++ b/packages/mui-layout/src/components/internal/SharedCollapseBtn.js
@@ -10,11 +10,11 @@ const CollapseBtn = ({
   ...props
 }) => {
   const ctx = useSidebarConfig();
-  const { setCollapsed, collapsed, opened, sidebar } = mapContext(ctx);
+  const { setCollapsed, collapsed, open, sidebar } = mapContext(ctx);
   if (
     !sidebar ||
     !sidebar.collapsible ||
-    (sidebar.variant === 'persistent' && !opened)
+    (sidebar.variant === 'persistent' && !open)
   ) {
     return null;
   }

--- a/packages/mui-layout/src/components/internal/SharedInsetSidebar.js
+++ b/packages/mui-layout/src/components/internal/SharedInsetSidebar.js
@@ -27,7 +27,7 @@ const SharedInsetSidebar = ({
 }) => {
   const { iBody } = useWindow();
   const parsedCtx = useSidebarConfig();
-  const { opened, setOpened } = parsedCtx;
+  const { open, setOpen } = parsedCtx;
   const { getWidth, getBodyStyle, getDrawerAnchor } = createInsetSidebar(
     parsedCtx
   );
@@ -40,9 +40,9 @@ const SharedInsetSidebar = ({
     return (
       <Drawer
         {...props}
-        open={opened}
+        open={open}
         onClose={() => {
-          setOpened(false);
+          setOpen(false);
         }}
         variant={'temporary'}
         anchor={getDrawerAnchor()}

--- a/packages/mui-layout/src/components/internal/SharedSidebar.js
+++ b/packages/mui-layout/src/components/internal/SharedSidebar.js
@@ -27,15 +27,15 @@ const SharedSidebar = ({
   const [entered, setEntered] = React.useState(false);
   const styles = useSidebarStyles();
   const transition = useTransitionStyles();
-  const { sidebar = {}, opened, setOpened, getSidebarZIndex } = parsedCtx;
+  const { sidebar = {}, open, setOpen, getSidebarZIndex } = parsedCtx;
   const { getWidth } = createEdgeSidebar(parsedCtx);
   const isPermanent = sidebar.variant === 'permanent';
   return (
     <Drawer
       {...props}
-      open={opened}
+      open={open}
       onClose={() => {
-        setOpened(false);
+        setOpen(false);
       }}
       variant={sidebar.variant}
       anchor={sidebar.anchor || 'left'}

--- a/packages/mui-layout/src/components/internal/SharedSidebarTrigger.js
+++ b/packages/mui-layout/src/components/internal/SharedSidebarTrigger.js
@@ -10,7 +10,7 @@ const SharedSidebarTrigger = ({
   ...props
 }) => {
   const parsedCtx = useSidebarConfig();
-  const { opened, setOpened, sidebar = {} } = parsedCtx;
+  const { open, setOpen, sidebar = {} } = parsedCtx;
   const { displayedAboveBreakpoint } = useInsetBreakpoint(parsedCtx);
   const isPermanentDrawer = !sidebar.inset && sidebar.variant === 'permanent';
   if (isPermanentDrawer || displayedAboveBreakpoint) {
@@ -21,7 +21,7 @@ const SharedSidebarTrigger = ({
       {...props}
       onClick={e => {
         onClick(e);
-        setOpened(!opened);
+        setOpen(!open);
       }}
     >
       {children}

--- a/packages/mui-layout/src/components/internal/SharedSidebarTriggerIcon.js
+++ b/packages/mui-layout/src/components/internal/SharedSidebarTriggerIcon.js
@@ -5,7 +5,7 @@ import ArrowRight from '@material-ui/icons/KeyboardArrowRightRounded';
 import MenuRounded from '@material-ui/icons/MenuRounded';
 
 const SharedSidebarTriggerIcon = ({ useSidebarConfig, ...props }) => {
-  const { opened, sidebar } = useSidebarConfig();
+  const { open, sidebar } = useSidebarConfig();
   const getArrow = () => {
     if (sidebar.anchor === 'left') {
       return <ArrowLeft {...props} />;
@@ -15,7 +15,7 @@ const SharedSidebarTriggerIcon = ({ useSidebarConfig, ...props }) => {
     }
     return null;
   };
-  return opened ? getArrow() : <MenuRounded {...props} />;
+  return open ? getArrow() : <MenuRounded {...props} />;
 };
 
 SharedSidebarTriggerIcon.propTypes = {

--- a/packages/mui-layout/src/core/layoutContext.d.ts
+++ b/packages/mui-layout/src/core/layoutContext.d.ts
@@ -4,20 +4,26 @@ import { Config } from '../utils/ConfigGenerator/ConfigGenerator';
 
 export interface ILayoutContext extends ReturnType<Config<true>['get']> {
   screen?: Breakpoint;
-  opened: boolean;
-  setOpened: (value: boolean) => void;
+  open: boolean;
+  opened: boolean; // removed in next major changed #555
+  setOpen: (value: boolean) => void;
+  setOpened: (value: boolean) => void; // removed in next major changed #555
   collapsed: boolean;
   setCollapsed: (value: boolean) => void;
-  secondaryOpened: boolean;
-  setSecondaryOpened: (value: boolean) => void;
+  secondaryOpen: boolean;
+  secondaryOpened: boolean; // removed in next major changed #555
+  setSecondaryOpen: (value: boolean) => void;
+  setSecondaryOpened: (value: boolean) => void; // removed in next major changed #555
   secondaryCollapsed: boolean;
   setSecondaryCollapsed: (value: boolean) => void;
 }
 
 export interface LayoutProviderProps {
-  initialOpened?: boolean;
+  initialOpen?: boolean;
+  initialOpened?: boolean; // removed in next major changed #555
   initialCollapsed?: boolean;
-  initialSecondaryOpened?: boolean;
+  initialSecondaryOpen?: boolean;
+  initialSecondaryOpened?: boolean; // removed in next major changed #555
   initialSecondaryCollapsed?: boolean;
   config?: Partial<Config<true>>;
   children: ReactNode;

--- a/packages/mui-layout/src/core/layoutContext.js
+++ b/packages/mui-layout/src/core/layoutContext.js
@@ -12,15 +12,17 @@ const LayoutProvider = ({
   config,
   parseConfig,
   children,
-  initialOpened,
+  initialOpened, // removed in next major changed #555
+  initialOpen = initialOpened,
   initialCollapsed,
-  initialSecondaryOpened,
+  initialSecondaryOpened, // removed in next major changed #555
+  initialSecondaryOpen = initialSecondaryOpened,
   initialSecondaryCollapsed,
 }) => {
-  const [opened, setOpened] = React.useState(initialOpened);
+  const [open, setOpen] = React.useState(initialOpen);
   const [collapsed, setCollapsed] = React.useState(initialCollapsed);
-  const [secondaryOpened, setSecondaryOpened] = React.useState(
-    initialSecondaryOpened
+  const [secondaryOpen, setSecondaryOpen] = React.useState(
+    initialSecondaryOpen
   );
   const [secondaryCollapsed, setSecondaryCollapsed] = React.useState(
     initialSecondaryCollapsed
@@ -44,12 +46,14 @@ const LayoutProvider = ({
         secondaryCollapsedBreakpoint: config.secondaryCollapsedBreakpoint,
         secondaryHeightAdjustmentDisabled:
           config.secondaryHeightAdjustmentDisabled,
-        opened,
-        setOpened,
+        open,
+        opened: open, // removed in next major changed #555
+        setOpen,
+        setOpened: setOpen, // removed in next major changed #555
         collapsed,
         setCollapsed,
-        secondaryOpened,
-        setSecondaryOpened,
+        secondaryOpen,
+        setSecondaryOpen,
         secondaryCollapsed,
         setSecondaryCollapsed,
       }}
@@ -59,9 +63,11 @@ const LayoutProvider = ({
   );
 };
 LayoutProvider.propTypes = {
-  initialOpened: PropTypes.bool,
+  initialOpened: PropTypes.bool, // removed in next major changed #555
+  initialOpen: PropTypes.bool,
   initialCollapsed: PropTypes.bool,
-  initialSecondaryOpened: PropTypes.bool,
+  initialSecondaryOpened: PropTypes.bool, // removed in next major changed #555
+  initialSecondaryOpen: PropTypes.bool,
   initialSecondaryCollapsed: PropTypes.bool,
   config: PropTypes.shape({
     autoCollapseDisabled: PropTypes.bool,
@@ -85,8 +91,10 @@ LayoutProvider.propTypes = {
   parseConfig: PropTypes.func,
 };
 LayoutProvider.defaultProps = {
-  initialOpened: false,
-  initialCollapsed: false,
+  initialOpen: undefined,
+  initialOpened: false, // removed in next major changed #555
+  initialCollapsed: false, // removed in next major changed #555
+  initialSecondaryOpen: undefined,
   initialSecondaryOpened: false,
   initialSecondaryCollapsed: false,
   config: defaultLayoutPreset,

--- a/packages/mui-layout/src/models/edgeEffect.js
+++ b/packages/mui-layout/src/models/edgeEffect.js
@@ -9,7 +9,7 @@ const attachOperator = (value, operator) =>
     : `${operator.toString().substr(0, 1)}${value}`;
 
 export default (ctx = {}) => {
-  const { header = {}, sidebar = {}, opened } = ctx;
+  const { header = {}, sidebar = {}, open } = ctx;
   const edgeSidebar = createEdgeSidebar(ctx);
 
   const incrementZIndex = (theme, plus) => ({
@@ -43,12 +43,12 @@ export default (ctx = {}) => {
         };
       }
       if (sidebar.variant === 'persistent') {
-        if (!opened) {
+        if (!open) {
           return {
             [`margin${upperFirst(sidebar.anchor)}`]: 0,
           };
         }
-        // opened
+        // open
         if (persistentBehavior === 'fit') {
           return {
             [`margin${upperFirst(sidebar.anchor)}`]: sidebarWidth,
@@ -61,7 +61,7 @@ export default (ctx = {}) => {
         }
         return {
           [`margin${upperFirst(sidebar.anchor)}`]:
-            opened &&
+            open &&
             (persistentBehavior === 'fit' || persistentBehavior === 'flexible')
               ? sidebarWidth
               : 0,
@@ -75,7 +75,7 @@ export default (ctx = {}) => {
       }
       if (sidebar.variant === 'persistent') {
         return createWidth(
-          opened && persistentBehavior === 'fit' ? sidebarWidth : 0
+          open && persistentBehavior === 'fit' ? sidebarWidth : 0
         );
       }
       return createWidth();

--- a/website/src/__tests__/modules/Path.test.js
+++ b/website/src/__tests__/modules/Path.test.js
@@ -3,16 +3,9 @@ import createLayout from '../../modules/path';
 jest.mock('../../constants/menus', () => {
   return {
     __esModule: true,
-    default: {
-      nav: ['nav'],
-      components: ['components'],
-      layouts: ['layouts'],
-    },
-    PKG: {
-      nav: 'nav',
-      components: 'components',
-      layouts: 'layouts',
-    },
+    COMPONENT_MENUS: ['components'],
+    LAYOUT_MENUS: ['layouts'],
+    STYLE_MENUS: [],
   };
 });
 

--- a/website/src/pages/layout/index.js
+++ b/website/src/pages/layout/index.js
@@ -129,7 +129,7 @@ const LayoutPage = () => {
         Material UI <Link underline={'none'}>Layout</Link>
       </Typography>
       <Typography gutterBottom>
-        <b>Version 2.0-beta</b>
+        <b>Version 3</b>
       </Typography>
       <Typography indent={'small'}>
         Layout is a group of Material-UI components that are enhanced and


### PR DESCRIPTION
closes #555 

This fix still expose `opened` for previous usage (will be removed in the next major change). From now on please use `open` instead.