### PR TITLE
SEO fix for SharedCollapseBtn.js

### DIFF
--- a/packages/mui-layout/src/components/internal/SharedCollapseBtn.js
+++ b/packages/mui-layout/src/components/internal/SharedCollapseBtn.js
@@ -25,6 +25,7 @@ const CollapseBtn = ({
         setCollapsed(!collapsed);
       }}
       {...props}
+      aria-label="open drawer"
     />
   );
 };


### PR DESCRIPTION
The `Google Chrome lighthouse` flagged a lack of the `aria-label` in the sidebar open drawer button. This PR aims at fixing this in order to help with the SEO of websites using this library.

![image](https://user-images.githubusercontent.com/11601622/79056080-893b2400-7c4a-11ea-8466-119fa3945b94.png)

Disclaimer: I am not very familiar with `TypeScript`, therefore I added the missing property directly to the component, please feel free to improve on it and add it as a `TypeScript prop`.