### PR TITLE
Updated for the issue #722

### DIFF
--- a/website/src/docs/components/card/blog/BlogCard.js
+++ b/website/src/docs/components/card/blog/BlogCard.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import cx from 'clsx';
-import { makeStyles } from '@material-ui/styles';
+import { makeStyles } from '@material-ui/core/styles';
 import Card from '@material-ui/core/Card';
 import CardMedia from '@material-ui/core/CardMedia';
 import CardContent from '@material-ui/core/CardContent';

--- a/website/src/docs/components/card/elevatedHeader/ElevatedHeaderCard.js
+++ b/website/src/docs/components/card/elevatedHeader/ElevatedHeaderCard.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import cx from 'clsx';
-import { makeStyles } from '@material-ui/styles';
+import { makeStyles } from '@material-ui/core/styles';
 import Card from '@material-ui/core/Card';
 import Table from '@material-ui/core/Table';
 import TableHead from '@material-ui/core/TableHead';

--- a/website/src/docs/components/card/engagement/EngagementCard.js
+++ b/website/src/docs/components/card/engagement/EngagementCard.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import cx from 'clsx';
-import { makeStyles } from '@material-ui/styles';
+import { makeStyles } from '@material-ui/core/styles';
 import Box from '@material-ui/core/Box';
 import Card from '@material-ui/core/Card';
 import CardContent from '@material-ui/core/CardContent';

--- a/website/src/docs/components/card/music/MusicCard.js
+++ b/website/src/docs/components/card/music/MusicCard.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import cx from 'clsx';
-import { makeStyles } from '@material-ui/styles';
+import { makeStyles } from '@material-ui/core/styles';
 import Card from '@material-ui/core/Card';
 import CardMedia from '@material-ui/core/CardMedia';
 import CardContent from '@material-ui/core/CardContent';

--- a/website/src/docs/components/card/news/NewsCard.js
+++ b/website/src/docs/components/card/news/NewsCard.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import cx from 'clsx';
-import { makeStyles } from '@material-ui/styles';
+import { makeStyles } from '@material-ui/core/styles';
 import Card from '@material-ui/core/Card';
 import CardMedia from '@material-ui/core/CardMedia';
 import CardContent from '@material-ui/core/CardContent';

--- a/website/src/docs/components/card/news2/NewsCard2.js
+++ b/website/src/docs/components/card/news2/NewsCard2.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import cx from 'clsx';
-import { makeStyles } from '@material-ui/styles';
+import { makeStyles } from '@material-ui/core/styles';
 import Box from '@material-ui/core/Box';
 import Card from '@material-ui/core/Card';
 import CardActionArea from '@material-ui/core/CardActionArea';

--- a/website/src/docs/components/card/planeTicket/PlaneTicketCard.js
+++ b/website/src/docs/components/card/planeTicket/PlaneTicketCard.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import cx from 'clsx';
-import { makeStyles } from '@material-ui/styles';
+import { makeStyles } from '@material-ui/core/styles';
 import Card from '@material-ui/core/Card';
 import CardMedia from '@material-ui/core/CardMedia';
 import AirplanemodeActive from '@material-ui/icons/AirplanemodeActive';

--- a/website/src/docs/components/card/post/PostCard.js
+++ b/website/src/docs/components/card/post/PostCard.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import cx from 'clsx';
-import { makeStyles } from '@material-ui/styles';
+import { makeStyles } from '@material-ui/core/styles';
 import Avatar from '@material-ui/core/Avatar';
 import Box from '@material-ui/core/Box';
 import Card from '@material-ui/core/Card';

--- a/website/src/docs/components/card/profile/ProfileCard.js
+++ b/website/src/docs/components/card/profile/ProfileCard.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import cx from 'clsx';
-import { makeStyles } from '@material-ui/styles';
+import { makeStyles } from '@material-ui/core/styles';
 import Box from '@material-ui/core/Box';
 import Card from '@material-ui/core/Card';
 import CardContent from '@material-ui/core/CardContent';

--- a/website/src/docs/components/card/project/ProjectCard.js
+++ b/website/src/docs/components/card/project/ProjectCard.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import cx from 'clsx';
-import { makeStyles } from '@material-ui/styles';
+import { makeStyles } from '@material-ui/core/styles';
 import Card from '@material-ui/core/Card';
 import CardContent from '@material-ui/core/CardContent';
 import BrandCardHeader from '@mui-treasury/components/cardHeader/brand';

--- a/website/src/docs/components/card/review/ReviewCard.js
+++ b/website/src/docs/components/card/review/ReviewCard.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import cx from 'clsx';
-import { makeStyles } from '@material-ui/styles';
+import { makeStyles } from '@material-ui/core/styles';
 import Box from '@material-ui/core/Box';
 import Card from '@material-ui/core/Card';
 import CardMedia from '@material-ui/core/CardMedia';

--- a/website/src/docs/components/card/review2/ReviewCard2.js
+++ b/website/src/docs/components/card/review2/ReviewCard2.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import cx from 'clsx';
-import { makeStyles } from '@material-ui/styles';
+import { makeStyles } from '@material-ui/core/styles';
 import Box from '@material-ui/core/Box';
 import Link from '@material-ui/core/Link';
 import Card from '@material-ui/core/Card';

--- a/website/src/docs/components/card/reward/RewardCard.js
+++ b/website/src/docs/components/card/reward/RewardCard.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { makeStyles } from '@material-ui/styles';
+import { makeStyles } from '@material-ui/core/styles';
 import Button from '@material-ui/core/Button';
 import Card from '@material-ui/core/Card';
 import CardMedia from '@material-ui/core/CardMedia';

--- a/website/src/docs/components/carousel/parallax/ParallaxCarousel.js
+++ b/website/src/docs/components/carousel/parallax/ParallaxCarousel.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import cx from 'clsx';
-import { makeStyles } from '@material-ui/styles';
+import { makeStyles } from '@material-ui/core/styles';
 import Typography from '@material-ui/core/Typography';
 import Button from '@material-ui/core/Button';
 import KeyboardArrowRight from '@material-ui/icons/KeyboardArrowRight';

--- a/website/src/docs/components/slide/parallax/ParallaxSlideDemo.js
+++ b/website/src/docs/components/slide/parallax/ParallaxSlideDemo.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { makeStyles } from '@material-ui/styles';
+import { makeStyles } from '@material-ui/core/styles';
 import Box from '@material-ui/core/Box';
 import Typography from '@material-ui/core/Typography';
 import ParallaxSlide from '@mui-treasury/components/slide/parallax';

--- a/website/src/docs/styles/cardHeader/official/OfficialCardHeader.js
+++ b/website/src/docs/styles/cardHeader/official/OfficialCardHeader.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { makeStyles } from '@material-ui/styles';
+import { makeStyles } from '@material-ui/core/styles';
 import CardHeader from '@material-ui/core/CardHeader';
 import Avatar from '@material-ui/core/Avatar';
 import IconButton from '@material-ui/core/IconButton';


### PR DESCRIPTION
Updated import statements `import { makeStyles } from '@material-ui/styles';` to `import { makeStyles } from '@material-ui/cor/styles';` for the latest material-ui core. And I tested all of them render correctly.

Close #722 if this PR has been merged.