### PR TITLE
Fix font color typo in minimalSelect.styles.js

### DIFF
--- a/packages/mui-styles/src/select/minimal/minimalSelect.styles.js
+++ b/packages/mui-styles/src/select/minimal/minimalSelect.styles.js
@@ -4,7 +4,7 @@ export default () => ({
   select: {
     minWidth: 200,
     background: 'white',
-    color: deepPurple[50],
+    color: deepPurple[500],
     fontWeight:200,
     borderStyle:'none',
     borderWidth: 2,


### PR DESCRIPTION
The MinimalSelect component is a select box with a white background color.  The font color was an extremely-light purple, which was extremely difficult to see on the white background.

I took a look at the source and I'm pretty sure that shade `50` is supposed to be `500`.

Using value `50`:
<img width="338" alt="Schermata 2020-10-15 alle 12 12 13 PM" src="https://user-images.githubusercontent.com/860303/96157035-cc1ed280-0edf-11eb-9b9e-12cb4d178754.png">

Using value `500`:
<img width="325" alt="Schermata 2020-10-15 alle 12 12 28 PM" src="https://user-images.githubusercontent.com/860303/96157062-d4770d80-0edf-11eb-9397-6fba634e8c8c.png">

This PR fixes issue #956

