### PR TITLE
Update EdgeHeaderOffset

### DIFF
--- a/packages/mui-layout/src/components/EdgeHeaderOffset/EdgeHeaderOffset.tsx
+++ b/packages/mui-layout/src/components/EdgeHeaderOffset/EdgeHeaderOffset.tsx
@@ -32,7 +32,7 @@ export default (styled: any) => {
     return (
       <Div
         className={cx('EdgeHeaderOffset', transition.smooth)}
-        styles={{ ...styles, flexShrink: 0 }}
+        styles={{ ...styles, flexShrink: 'inherit' }}
         style={inlineStyle}
       />
     );


### PR DESCRIPTION
flexShrink making the sidenav move to the top, whenever the height of the content in the sidenav is higher than the current screen height, and if this happens the content gets covered by the header, if it settled to the clipped: true however, settled it to the inherit do what it need